### PR TITLE
Add OS column to generated tables

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ function displayXMLAsTable(xml) {
     table.classList.add('uk-table');
     table.classList.add('uk-table-divider');
 
-    const headers = ['Environment Id', 'Machine Id', 'AlternateId', 'Role Id'];
+    const headers = ['Environment Id', 'Machine Id', 'AlternateId', 'Role Id', 'OS'];
     
     // Create table header
     const thead = document.createElement('thead');
@@ -63,6 +63,9 @@ function displayXMLAsTable(xml) {
         Array.from(machines).forEach(machine => {
             const machineId = machine.getElementsByTagName('Id')[0].textContent;
             const alternateId = machine.getElementsByTagName('AlternateId')[0].textContent;
+            const osFamily = machine.getElementsByTagName('family')[0].textContent;
+            const osArch = machine.getElementsByTagName('arch')[0].textContent;
+            const os = `${osFamily} ${osArch}`;
             const roles = Array.from(machine.getElementsByTagName('Role')); // Ensure roles is an array
             const roleCount = roles.length;
 
@@ -94,6 +97,13 @@ function displayXMLAsTable(xml) {
                     alternateIdCell.style.borderBottom = '2px solid #000'; // Thicker bottom border for alternateId rows
                     alternateIdCell.style.padding = '12px 15px';
                     tr.appendChild(alternateIdCell);
+
+                    const osCell = document.createElement('td');
+                    osCell.textContent = os;
+                    osCell.rowSpan = roleCount;
+                    osCell.style.borderBottom = '2px solid #000'; // Thicker bottom border for OS rows
+                    osCell.style.padding = '12px 15px';
+                    tr.appendChild(osCell);
                 }
 
                 const roleId = role.getElementsByTagName('Id')[0].textContent;

--- a/table.js
+++ b/table.js
@@ -7,7 +7,7 @@ function displayXMLAsTable(xml) {
     table.classList.add('uk-table');
     table.classList.add('uk-table-divider');
 
-    const headers = ['Environment Id', 'Machine Id', 'AlternateId', 'Role Id'];
+    const headers = ['Environment Id', 'Machine Id', 'AlternateId', 'Role Id', 'OS'];
     
     // Create table header
     const thead = document.createElement('thead');
@@ -37,6 +37,9 @@ function displayXMLAsTable(xml) {
         Array.from(machines).forEach(machine => {
             const machineId = machine.getElementsByTagName('Id')[0].textContent;
             const alternateId = machine.getElementsByTagName('AlternateId')[0].textContent;
+            const osFamily = machine.getElementsByTagName('family')[0].textContent;
+            const osArch = machine.getElementsByTagName('arch')[0].textContent;
+            const os = `${osFamily} ${osArch}`;
             const roles = Array.from(machine.getElementsByTagName('Role')); // Ensure roles is an array
             const roleCount = roles.length;
 
@@ -68,6 +71,13 @@ function displayXMLAsTable(xml) {
                     alternateIdCell.style.borderBottom = '2px solid #000'; // Thicker bottom border for alternateId rows
                     alternateIdCell.style.padding = '12px 15px';
                     tr.appendChild(alternateIdCell);
+
+                    const osCell = document.createElement('td');
+                    osCell.textContent = os;
+                    osCell.rowSpan = roleCount;
+                    osCell.style.borderBottom = '2px solid #000'; // Thicker bottom border for OS rows
+                    osCell.style.padding = '12px 15px';
+                    tr.appendChild(osCell);
                 }
 
                 const roleId = role.getElementsByTagName('Id')[0].textContent;


### PR DESCRIPTION
Add OS column to generated tables to include OS family and OS architecture.

* Update `script.js` to add 'OS' to the `headers` array in the `displayXMLAsTable` function.
* Extract `os family` and `os arch` from the XML and add them to the table rows in the `displayXMLAsTable` function in `script.js`.
* Update `table.js` to add 'OS' to the `headers` array in the `displayXMLAsTable` function.
* Extract `os family` and `os arch` from the XML and add them to the table rows in the `displayXMLAsTable` function in `table.js`.

