### PR TITLE
Add compressed XML query parameter handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,8 +17,9 @@ function handleHttpQueryPayload() {
     const urlParams = new URLSearchParams(window.location.search);
     const xmlData = urlParams.get('xmlData');
     if (xmlData) {
+        const decompressedXmlData = decompressData(xmlData); // Decompress the xmlData
         const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(xmlData, "text/xml");
+        const xmlDoc = parser.parseFromString(decompressedXmlData, "text/xml");
         displayXMLAsTable(xmlDoc);
         generateLink(xmlDoc); // Call generateLink after XML is parsed and displayed
     }


### PR DESCRIPTION
Modify `handleHttpQueryPayload` function in `script.js` to handle compressed XML query parameters and display decompressed XML data.

* Add decompression of `xmlData` using `decompressData` function.
* Parse the decompressed XML data and display it as a table.
* Call `generateLink` after XML is parsed and displayed.

